### PR TITLE
Remove unnecessary prints in Search method

### DIFF
--- a/client.go
+++ b/client.go
@@ -148,14 +148,12 @@ func (c *Client) Search(query map[string]string) (r TorrentResults, err error) {
 		return
 	}
 
-	fmt.Println(resp.StatusCode)
 	if err != nil {
 		return
 	}
 	defer resp.Body.Close()
 	b, err := ioutil.ReadAll(resp.Body)
 
-	fmt.Println(string(b))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
The client works as expected, but the fmt.Printlns should be removed as you don't expect this code to do some write lines when you want to search for something.